### PR TITLE
Fix event request form submit state

### DIFF
--- a/app/components/forms/event-request/event-request.tsx
+++ b/app/components/forms/event-request/event-request.tsx
@@ -146,11 +146,11 @@ export function EventInfoRequestModal({
 
     if (!validateForm(formValues)) return;
 
+    setIsSubmitting(true);
     try {
       const response = await sendEventRequest(formDataToSend);
       if (!response) throw new Error('Algo salio mal');
 
-      setIsSubmitting(true);
       setIsSuccess(true);
       setTimeout(() => {
         setFormValues({
@@ -168,6 +168,8 @@ export function EventInfoRequestModal({
       }, 3000);
     } catch (error) {
       setIsSuccess(false);
+    } finally {
+      setIsSubmitting(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- fix `EventInfoRequestModal` to set and reset `isSubmitting` correctly

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1d06c9148321b58c82d8920ae0f3